### PR TITLE
Email purchase tracking & discount code tracking

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>loyaltylion</name>
 	<displayName><![CDATA[LoyaltyLion]]></displayName>
-	<version><![CDATA[1.2.2]]></version>
+	<version><![CDATA[1.2.3]]></version>
 	<description><![CDATA[Add a loyalty program to your store in minutes. Increase customer loyalty and happiness by rewarding referrals, purchases, signups, reviews and visits.]]></description>
 	<author><![CDATA[LoyaltyLion]]></author>
 	<tab><![CDATA[advertising_marketing]]></tab>

--- a/loyaltylion.php
+++ b/loyaltylion.php
@@ -612,6 +612,22 @@ class LoyaltyLion extends Module
 		if ($tracking_id)
 			$data['tracking_id'] = $tracking_id;
 
+		$cart_rules = $order->getCartRules();
+
+		if (!empty($cart_rules)) {
+			$data['discount_codes'] = array();
+
+			foreach ($cart_rules as $cart_rule) {
+				if (!$cart_rule['name'] || !$cart_rule['value'])
+					continue;
+
+				$data['discount_codes'][] = array(
+					'code' => $cart_rule['name'],
+					'amount' => $cart_rule['value'],
+				);
+			}
+		}
+
 		$this->loadLoyaltyLionClient();
 		$response = $this->client->orders->create($data);
 

--- a/loyaltylion.php
+++ b/loyaltylion.php
@@ -400,6 +400,17 @@ class LoyaltyLion extends Module
 		if ($referral_id && !$this->context->cookie->loyaltylion_referral_id)
 			$this->context->cookie->__set('loyaltylion_referral_id', $referral_id);
 
+		$tracking_id = Tools::getValue('ll_eid');
+
+		if ($tracking_id) {
+			// I don't trust using $_SESSION as it's never used anywhere else in PrestaShop, so I'm
+			// concerned it might randomly break other installs. So instead we'll use the standard cookie
+			// store, but just in case it ends up being persisted forever, we'll prefix the tracking id
+			// with a timestamp so we can only send it when tracking if it's less than 24 hrs old
+			$value = time().':::'.$tracking_id;
+			$this->context->cookie->__set('loyaltylion_tracking_id', $value);
+		}
+
 		$customer = $this->context->customer;
 
 		$this->context->smarty->assign(array(
@@ -445,6 +456,11 @@ class LoyaltyLion extends Module
 
 		if ($this->context->cookie->loyaltylion_referral_id)
 			$data['referral_id'] = $this->context->cookie->loyaltylion_referral_id;
+
+		$tracking_id = $this->getTrackingIdFromCookie();
+
+		if ($tracking_id)
+			$data['tracking_id'] = $tracking_id;
 
 		$this->loadLoyaltyLionClient();
 
@@ -507,7 +523,7 @@ class LoyaltyLion extends Module
 	 * Hook into `ProductComment` deletes, which lets us track when a product comment has been
 	 * deleted and tell the LoyaltyLion API so any points for that review can be removed. This
 	 * only supports the official Prestashop product comments module
-	 * 
+	 *
 	 * @param  [type] $params [description]
 	 * @return [type]         [description]
 	 */
@@ -533,7 +549,7 @@ class LoyaltyLion extends Module
 	 * Hook into `ProductComment` validations, which lets us track when a product comment has been
 	 * moderated and tell the LoyaltyLion API so any points for that review can be approved. This
 	 * only supports the official Prestashop product comments module
-	 * 
+	 *
 	 * @param  [type] $params [description]
 	 * @return [type]         [description]
 	 */
@@ -590,6 +606,11 @@ class LoyaltyLion extends Module
 
 		if ($this->context->cookie->loyaltylion_referral_id)
 			$data['referral_id'] = $this->context->cookie->loyaltylion_referral_id;
+
+		$tracking_id = $this->getTrackingIdFromCookie();
+
+		if ($tracking_id)
+			$data['tracking_id'] = $tracking_id;
 
 		$this->loadLoyaltyLionClient();
 		$response = $this->client->orders->create($data);
@@ -989,6 +1010,32 @@ class LoyaltyLion extends Module
 	}
 
 	/**
+	 * Check the current cookie for a LoyaltyLion `tracking_id`
+	 *
+	 * If this id exists, and has not expired, it will be returned
+	 *
+	 * @return [type] Tracking id or null if it doesn't exist or has expired
+	 */
+	private function getTrackingIdFromCookie() {
+		if (!$this->context->cookie->loyaltylion_tracking_id)
+			return null;
+
+		$values = explode(':::', $this->context->cookie->loyaltylion_tracking_id);
+
+		if (empty($values))
+			return null;
+
+		if (count($values) != 2)
+			return $values[0];
+
+		// for now, let's have a 24 hour expiration time on the timestamp
+		if (time() - (int)$values[0] > 86400)
+			return null;
+
+		return $values[1];
+	}
+
+	/**
 	 * Get a PrestaShop currency by looking it up with an `iso_code`
 	 *
 	 * If a currency with this code exists, it will be returned (as an associative array, not
@@ -1011,7 +1058,7 @@ class LoyaltyLion extends Module
 	/**
 	 * Iterates over all currencies, if iso code of currency
 	 * is same with currency code we look for, returs the id of it.
-	 * 
+	 *
 	 * @param  [type] $code [description]
 	 * @return [type]       [description]
 	 */
@@ -1029,7 +1076,7 @@ class LoyaltyLion extends Module
 	 * Render immediately (i.e. for ajax requests)
 	 *
 	 * If an array is provided as $body this will render a JSON response
-	 * 
+	 *
 	 * @param  [type]  $body        [description]
 	 * @param  integer $status_code [description]
 	 * @return [type]               [description]

--- a/loyaltylion.php
+++ b/loyaltylion.php
@@ -44,7 +44,7 @@ class LoyaltyLion extends Module
 	{
 		$this->name = 'loyaltylion';
 		$this->tab = 'advertising_marketing';
-		$this->version = '1.2.2';
+		$this->version = '1.2.3';
 		$this->author = 'LoyaltyLion';
 		$this->need_instance = 0;
 


### PR DESCRIPTION
We've recently added support for automated emails using LoyaltyLion. In order to effectively track the impact of these emails we've made a small change to the LoyaltyLion module so that it stores the `ll_eid` query parameter in the cookie and then sends it on when tracking activity or orders.

This PR also adds a minor improvement to our order tracking, so that it now sends through any discounts that were applied to an order when tracking it. This allows LoyaltyLion to mark vouchers as used in our system, once they've been applied to an order.